### PR TITLE
Updating bespoken virtual device reference

### DIFF
--- a/lambda/custom/testing.json
+++ b/lambda/custom/testing.json
@@ -6,7 +6,7 @@
   "locale": "en-US",
   "interactionModel": "../../models/en-US.json",
   "trace": false,
-  "virtualDeviceToken": "<See test/README.MD for setup>",
+  "virtualDeviceToken": "<Get token at apps.bespoken.io>",
   "jest": {
     "collectCoverageFrom": ["*.js"],
     "silent": false,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This is a slight change in Bespoken's testing.json configuration file to make it easier for developers to get a free virtual device token and get started.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
